### PR TITLE
Issue-10:_added_vcpkg _visualStudio_integration_step

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,14 @@ To run a sample project in this repository, take the following steps:
       ```  
    1. Install the required packages:
       ```bash
-        .\vcpkg.exe install jsoncpp:x64-windows
-        .\vcpkg.exe install curl:x64-windows
-        .\vcpkg.exe install opencv:x64-windows
+      .\vcpkg.exe install jsoncpp:x64-windows
+      .\vcpkg.exe install curl:x64-windows
+      .\vcpkg.exe install opencv:x64-windows
       ```
    1. Ensure `vcpkg` Integration with Visual Studio:
 	  Make sure you have integrated vcpkg with Visual Studio. After cloning vcpkg and installing libraries, you need to run the integration command:
 	  ```bash
-		./vcpkg.exe integrate install
+	  ./vcpkg.exe integrate install
 	  ```
 	  This command should provide a message indicating successful integration with Visual Studio.
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ To run a sample project in this repository, take the following steps:
         .\vcpkg.exe install curl:x64-windows
         .\vcpkg.exe install opencv:x64-windows
       ```
+   1. Ensure `vcpkg` Integration with Visual Studio:
+	  Make sure you have integrated vcpkg with Visual Studio. After cloning vcpkg and installing libraries, you need to run the integration command:
+	  ```bash
+		./vcpkg.exe integrate install
+	  ```
+	  This command should provide a message indicating successful integration with Visual Studio.
 
 1. **Modify the project configuration**
 


### PR DESCRIPTION
Issue :10 --https://github.com/AgoraIO/video-sdk-samples-windows/issues/10

One step for vcpkg-visual studio integration is missing in the README file:

Ensure vcpkg Integration with Visual Studio
Make sure you have integrated vcpkg with Visual Studio. After cloning vcpkg and installing libraries, you need to run the integration command:

./vcpkg.exe integrate install 

This command should provide a message indicating successful integration with Visual Studio.

Actually This step is needed one time execution  and it support all time integrate with Visual Studio in that system.
Mean irrespective of how many repo you create in the system, this step is not required every time, if you have done once in your device.